### PR TITLE
fix: Remove stray backticks from SCSS file

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -385,4 +385,3 @@ footer {
     margin-top: 1.5em;
   }
 }
-```


### PR DESCRIPTION
This commit removes stray Markdown triple backticks from the end of the 'assets/css/style.scss' file. This error was causing the GitHub Pages Jekyll build to fail with an "Invalid CSS" error.

With this correction, the CSS should compile successfully, allowing the site to build and deploy.