### PR TITLE
feat: Update recipes with local images, full content display, and new…

### DIFF
--- a/_layouts/recipe.html
+++ b/_layouts/recipe.html
@@ -6,8 +6,6 @@ layout: default
 
   {% if page.image and page.image != "" %}
     <img src="{{ page.image | relative_url }}" alt="{{ page.title | escape }}" class="recipe-image">
-  {% else %}
-    <img src="https://source.unsplash.com/800x400/?{{ page.title | url_encode }},food,recipe" alt="Placeholder image for {{ page.title | escape }}" class="recipe-image">
   {% endif %}
 
   <section class="recipe-meta">

--- a/_recipes/test-image-recipe.md
+++ b/_recipes/test-image-recipe.md
@@ -1,0 +1,27 @@
+---
+layout: recipe
+title: Actual Recipe Title in Content
+prep_time: 15 Minuten (from content)
+cook_time: 20 Min from FM
+portions: 2 from FM
+ingredients:
+- 1 kg Content Ingredient
+- 2 tbsp Content Spice
+image: /rezepte/images/test-image.jpg
+---
+
+# Actual Recipe Title in Content
+
+This is some intro text.
+
+Vorbereitungszeit: 15 Minuten (from content)
+
+## Zutaten
+
+- 1 kg Content Ingredient
+- 2 tbsp Content Spice
+
+## Zubereitung
+
+1.  Do this.
+2.  Then that.

--- a/_tools/process_recipes.py
+++ b/_tools/process_recipes.py
@@ -1,6 +1,26 @@
 import re
 import os
 import sys
+import yaml # For parsing front matter
+
+# Helper to extract front matter and content
+def extract_front_matter(text_content):
+    front_matter = {}
+    main_content = text_content
+
+    if text_content.startswith("---"):
+        try:
+            end_fm = text_content.find("---", 3)
+            if end_fm != -1:
+                fm_text = text_content[3:end_fm]
+                front_matter = yaml.safe_load(fm_text) or {} # Ensure it's a dict
+                main_content = text_content[end_fm + 3:].lstrip()
+        except yaml.YAMLError as e:
+            print(f"Warning: Could not parse existing YAML front matter: {e}")
+        except Exception as e:
+            print(f"Warning: Error processing front matter: {e}")
+
+    return front_matter, main_content
 
 def parse_recipe(filepath):
     """
@@ -17,46 +37,54 @@ def parse_recipe(filepath):
         print(f"Error reading file {filepath}: {e}")
         return None
 
-    # Placeholder for parsing logic
-    title = "Extracted Title Placeholder"
-    prep_time = "Extracted Prep Time Placeholder"
-    cook_time = "Extracted Cook Time Placeholder"
-    portions = "Extracted Portions Placeholder"
-    ingredients = ["Ingredient 1 Placeholder", "Ingredient 2 Placeholder"]
-    instructions_content = "## Zubereitung\n\nInstructions placeholder."
 
-    # Extract Title (from the first H1 heading)
-    title_match = re.search(r"^#\s*(.*)", content, re.MULTILINE)
+    existing_fm, main_markdown_content = extract_front_matter(content)
+
+    # Initialize variables, prioritizing existing front matter for image
+    image_path = existing_fm.get("image", "") # Get existing image path or default to empty
+
+    # Most parsing will now happen on main_markdown_content, not the full 'content'
+
+    # Extract Title (from the first H1 heading in main_markdown_content)
+    title_match = re.search(r"^#\s*(.*)", main_markdown_content, re.MULTILINE)
     if title_match:
         title = title_match.group(1).strip()
+    elif "title" in existing_fm: # Fallback to title in existing front matter
+        title = existing_fm["title"]
     else:
-        print(f"Warning: Title not found in {filepath}")
+        print(f"Warning: Title not found in H1 or front matter for {filepath}")
         title = "Untitled Recipe" # Default title
 
-    # Extract Prep Time
-    prep_time_match = re.search(r"Vorbereitungszeit:\s*(.*)", content, re.IGNORECASE)
+    # Extract Prep Time from main_markdown_content
+    prep_time_match = re.search(r"Vorbereitungszeit:\s*(.*)", main_markdown_content, re.IGNORECASE)
     if prep_time_match:
         prep_time = prep_time_match.group(1).replace("**", "").strip()
+    elif "prep_time" in existing_fm:
+        prep_time = existing_fm["prep_time"]
     else:
         prep_time = "" # Handle missing field
 
-    # Extract Cook Time
-    cook_time_match = re.search(r"Kochzeit:\s*(.*)", content, re.IGNORECASE)
+    # Extract Cook Time from main_markdown_content
+    cook_time_match = re.search(r"Kochzeit:\s*(.*)", main_markdown_content, re.IGNORECASE)
     if cook_time_match:
         cook_time = cook_time_match.group(1).replace("**", "").strip()
+    elif "cook_time" in existing_fm:
+        cook_time = existing_fm["cook_time"]
     else:
         cook_time = "" # Handle missing field
 
-    # Extract Portions
-    portions_match = re.search(r"Portionen:\s*(.*)", content, re.IGNORECASE)
+    # Extract Portions from main_markdown_content
+    portions_match = re.search(r"Portionen:\s*(.*)", main_markdown_content, re.IGNORECASE)
     if portions_match:
         portions = portions_match.group(1).replace("**", "").strip()
+    elif "portions" in existing_fm:
+        portions = existing_fm["portions"]
     else:
         portions = "" # Handle missing field
 
-    # Extract Ingredients
+    # Extract Ingredients from main_markdown_content
     ingredients_list = []
-    ingredients_section_match = re.search(r"## Zutaten\n\n(.*?)(?=\n## |\Z)", content, re.DOTALL | re.IGNORECASE)
+    ingredients_section_match = re.search(r"## Zutaten\n\n(.*?)(?=\n## |\Z)", main_markdown_content, re.DOTALL | re.IGNORECASE)
     if ingredients_section_match:
         ingredients_text = ingredients_section_match.group(1).strip()
         raw_lines = ingredients_text.split('\n')
@@ -69,54 +97,95 @@ def parse_recipe(filepath):
             line = re.sub(r"\[(.*?)\]\(.*?\)", r"\1", line) # Remove markdown links, keeping text
             if line:
                 ingredients_list.append(line.strip())
+    elif "ingredients" in existing_fm and isinstance(existing_fm["ingredients"], list):
+        ingredients_list = existing_fm["ingredients"]
     else:
-        print(f"Warning: Ingredients not found in {filepath}")
+        print(f"Warning: Ingredients not found in content or front matter for {filepath}")
 
-    # Extract Instructions (Zubereitung)
-    instructions_match = re.search(r"## Zubereitung\n\n(.*?)(?=\n## Hilfreiche Tipps|\Z)", content, re.DOTALL | re.IGNORECASE)
+    # Extract Instructions (Zubereitung) from main_markdown_content
+    # If "Zubereitung" section exists, it's the primary source for instructions.
+    # Otherwise, the whole main_markdown_content (after FM) is considered instructions.
+    instructions_content = main_markdown_content # Default to all content after FM
+    instructions_match = re.search(r"## Zubereitung\n\n(.*?)(?=\n## Hilfreiche Tipps|\Z)", main_markdown_content, re.DOTALL | re.IGNORECASE)
     if instructions_match:
         instructions_content = instructions_match.group(1).strip()
+        # Check if there's any meaningful content before "Zubereitung" that's not part of other extractions
+        # This part might need refinement if descriptions/intros are common before "Zutaten" or "Zubereitung"
+        # For now, if "Zubereitung" is found, we prioritize that.
+        # If an intro section exists before "Zutaten" or "Zubereitung", it might be lost with current logic
+        # unless it's part of the content before the first H1 that becomes the title.
+
     else:
-        # Fallback: if "Zubereitung" is not found, try to get content after last known metadata or ingredients
-        print(f"Warning: '## Zubereitung' section not found in {filepath}. Trying to infer content.")
-        # This is a basic fallback, might need refinement
-        last_known_section_end = 0
-        if ingredients_section_match:
-            last_known_section_end = ingredients_section_match.end()
-
-        # Try to find content that is not part of a known section
-        potential_content_start = content.find("Portionen:") # Example, find end of last metadata
-        if potential_content_start != -1:
-            potential_content_start = content.find('\n', potential_content_start) # Move to next line
-            if potential_content_start != -1:
-                 # Look for the next significant heading or end of file
-                next_heading_match = re.search(r"\n## ", content[potential_content_start:], re.IGNORECASE)
-                if next_heading_match:
-                    instructions_content = content[potential_content_start : potential_content_start + next_heading_match.start()].strip()
-                else:
-                    instructions_content = content[potential_content_start:].strip() # Take rest of the file
-            else:
-                instructions_content = "Instructions could not be reliably extracted."
+        # If no "Zubereitung" heading, check if there's an "instructions" field in existing FM
+        if "instructions" in existing_fm:
+             instructions_content = existing_fm["instructions"]
         else:
-             instructions_content = "Instructions could not be reliably extracted."
+            # If still no "Zubereitung" heading, we use main_markdown_content,
+            # but need to be careful if it contains the H1 title, metadata lines etc.
+            # The current logic for title/metadata extraction should ideally remove those parts already.
+            # This part is tricky: what if main_markdown_content *is* just the H1 title and metadata lines because there's no other body?
+            # For now, if "Zubereitung" is not found, the whole main_markdown_content is used.
+            # This might be okay if the file is purely a recipe instruction set without the specific heading.
+            # If the content was already "Instructions could not be reliably extracted." from a previous run, keep it.
+            if not main_markdown_content.strip() or main_markdown_content.strip() == "Instructions could not be reliably extracted.":
+                 instructions_content = "Instructions could not be reliably extracted."
+            # else, instructions_content is already main_markdown_content (this variable is no longer used for the main body)
+            print(f"Warning: '## Zubereitung' section not found in {filepath}. The full original content (after any original FM) will be used as the body.")
+
+    # The variable 'instructions_content' is no longer the definitive body for the output file.
+    # The body of the new file will be 'main_markdown_content'.
+    # The parsing logic above for title, ingredients, etc., is still valuable for the new front matter.
+    # Manual escaping of title, prep_time etc. for YAML is not strictly needed here if yaml.dump is robust,
+    # but it's kept for the new_front_matter_dict construction as a direct value.
+    # yaml.dump itself should handle quoting and escaping correctly for the final YAML string.
+
+    # Values for new_front_matter_dict should be the raw extracted ones.
+    new_front_matter_dict = {
+        "layout": "recipe",
+        "title": title,
+        "prep_time": prep_time,
+        "cook_time": cook_time,
+        "portions": portions,
+        "ingredients": ingredients_list,
+        "image": image_path # Use the preserved or default empty image_path
+    }
+
+    # Remove keys with empty string values, but keep image even if empty for Unsplash logic
+    # Also keep ingredients even if empty list.
+    # Note: The title, prep_time etc. going into new_front_matter_dict are already stripped and potentially modified.
+    final_fm_dict = {k: v for k, v in new_front_matter_dict.items() if v or k == "image" or k == "ingredients"}
 
 
-    # Construct new file content
-    front_matter = f"""---
-layout: recipe
-title: "{title}"
-prep_time: "{prep_time}"
-cook_time: "{cook_time}"
-portions: "{portions}"
-ingredients:
-"""
-    for ingredient in ingredients_list:
-        front_matter += f'  - "{ingredient}"\n'
-    front_matter += 'image: "" # Placeholder for now\n---\n\n'
+    try:
+        # Use yaml.dump to generate the front matter string for better handling of special characters
+        # and correct list formatting.
+        fm_yaml_string = yaml.dump(final_fm_dict, allow_unicode=True, default_flow_style=False, sort_keys=False)
+    except Exception as e:
+        print(f"Error dumping YAML for {filepath}: {e}")
+        # Fallback to basic string formatting if yaml.dump fails
+        # For this fallback, we DO need to ensure the strings are properly escaped for manual YAML construction.
+        escaped_title_fallback = str(final_fm_dict.get("title","")).replace('"', '\\"')
+        escaped_prep_fallback = str(final_fm_dict.get("prep_time","")).replace('"', '\\"')
+        escaped_cook_fallback = str(final_fm_dict.get("cook_time","")).replace('"', '\\"')
+        escaped_portions_fallback = str(final_fm_dict.get("portions","")).replace('"', '\\"')
+        escaped_image_fallback = str(final_fm_dict.get("image","")).replace('"', '\\"')
 
-    new_content = front_matter + instructions_content
+        fm_yaml_string = "layout: recipe\n"
+        fm_yaml_string += f'title: "{escaped_title_fallback}"\n'
+        if final_fm_dict.get("prep_time"): fm_yaml_string += f'prep_time: "{escaped_prep_fallback}"\n'
+        if final_fm_dict.get("cook_time"): fm_yaml_string += f'cook_time: "{escaped_cook_fallback}"\n'
+        if final_fm_dict.get("portions"): fm_yaml_string += f'portions: "{escaped_portions_fallback}"\n'
+        fm_yaml_string += f'image: "{escaped_image_fallback}"\n' # Always include image
+        fm_yaml_string += "ingredients:\n" # Always include ingredients key
+        for ing in final_fm_dict.get("ingredients", []):
+            escaped_ing = str(ing).replace('"', '\\"')
+            fm_yaml_string += f'  - "{escaped_ing}"\n'
 
-    return new_content, title
+    # The main change: use main_markdown_content as the body of the new file
+    new_content = f"---\n{fm_yaml_string}---\n\n{main_markdown_content}"
+
+    # The 'title' returned is the one extracted for front matter.
+    return new_content, final_fm_dict.get("title", "Untitled Recipe")
 
 def main():
     if len(sys.argv) < 2:

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,22 +1,26 @@
 ---
 ---
-// Variables
-$primary-color: #2c88d9; // A slightly more modern blue
-$secondary-color: #f39c12; // Accent orange for buttons or highlights
-$text-color: #34495e; // Darker gray for text
-$background-color: #f8f9fa; // Very light gray for page background
-$card-background: #ffffff;
-$border-color: #e9ecef; // Lighter border color
+@import url('https://fonts.googleapis.com/css2?family=Domine:wght@400;700&family=Open+Sans:wght@400;600&display=swap');
+
+// Variables - New Cooking Theme
+$primary-color: #D2691E; // Terracotta (Chocolate in CSS terms)
+$secondary-color: #DAA520; // Muted Gold (Goldenrod)
+$text-color: #5C4033;    // Dark Brown (VeryDarkBrown - custom)
+$background-color: #FAF0E6; // Light Cream (Linen)
+$card-background: #ffffff; // White
+$border-color: #e0d8cf; // Soft, light warm gray (Seashell-ish or lighter Parchment)
+
 $header-background: $primary-color;
 $header-text-color: #ffffff;
-$link-color: $primary-color;
-$link-hover-color: darken($primary-color, 10%);
+$link-color: darken($primary-color, 10%); // Darker terracotta for links
+$link-hover-color: darken($primary-color, 20%);
 
-// Font stacks
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-$font-family-serif: "Georgia", "Times New Roman", Times, serif;
+// Font stacks - New Cooking Theme
+$font-family-serif: 'Domine', "Georgia", "Times New Roman", Times, serif; // For headings
+$font-family-sans-serif: 'Open Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; // For body
 
-// Basic Reset
+
+// Basic Reset (remains the same)
 body, h1, h2, h3, h4, h5, h6, p, ul, ol, li, figure, figcaption, blockquote, dl, dd {
   margin: 0;
   padding: 0;
@@ -30,10 +34,10 @@ body, h1, h2, h3, h4, h5, h6, p, ul, ol, li, figure, figcaption, blockquote, dl,
 
 // Global Styles
 body {
-  font-family: $font-family-sans-serif;
+  font-family: $font-family-sans-serif; // Updated font
   line-height: 1.65;
-  background-color: $background-color;
-  color: $text-color;
+  background-color: $background-color; // Updated color
+  color: $text-color; // Updated color
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -41,22 +45,22 @@ body {
 
 .container {
   width: 90%;
-  max-width: 1140px; // Common max-width for containers
+  max-width: 1140px;
   margin: 0 auto;
   padding: 20px 15px;
   flex-grow: 1;
 }
 
 main {
-  flex-grow: 1; // Ensures main content pushes footer down
+  flex-grow: 1;
 }
 
 a {
-  color: $link-color;
+  color: $link-color; // Updated color
   text-decoration: none;
   transition: color 0.2s ease-in-out;
   &:hover {
-    color: $link-hover-color;
+    color: $link-hover-color; // Updated color
     text-decoration: underline;
   }
 }
@@ -64,26 +68,30 @@ a {
 img {
   max-width: 100%;
   height: auto;
-  display: block; // Removes bottom space under images
+  display: block;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: $font-family-serif; // More traditional for headings
+  font-family: $font-family-serif; // Updated font
   margin-bottom: 0.75em;
   line-height: 1.3;
-  color: darken($text-color, 10%);
+  color: $primary-color; // Headings now use primary color for more impact
 }
 
-h1 { font-size: 2.25em; }
-h2 { font-size: 1.75em; }
-h3 { font-size: 1.25em; }
+h1 { font-size: 2.5em; } // Slightly larger for the new theme
+h2 { font-size: 2em; }
+h3 { font-size: 1.5em; }
+h4 { font-size: 1.25em; }
+h5 { font-size: 1em; }
+h6 { font-size: 0.875em; }
+
 
 p {
   margin-bottom: 1em;
 }
 
 ul, ol {
-  padding-left: 20px; // Standard indentation for lists
+  padding-left: 20px;
   margin-bottom: 1em;
 }
 
@@ -93,12 +101,13 @@ li {
 
 // Header
 header {
-  background-color: $header-background;
-  color: $header-text-color;
+  background-color: $header-background; // Updated color
+  color: $header-text-color; // Updated color
   padding: 1.5em 0;
   margin-bottom: 2em;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1); // Subtle shadow for depth
 
-  .container { // To constrain header content
+  .container {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -106,12 +115,13 @@ header {
     padding-bottom: 0;
   }
 
-  h1 {
-    margin-bottom: 0.5em; // Adjust for search bar
+  h1 { // Site Title in Header
+    margin-bottom: 0.5em;
+    font-size: 2em; // Adjust size for header context
+    color: $header-text-color; // Ensure it uses header text color
     a {
-      color: $header-text-color;
+      color: $header-text-color; // Updated color
       text-decoration: none;
-      font-size: 1.5em; // Slightly smaller h1 in header
       &:hover {
         color: darken($header-text-color, 10%);
       }
@@ -121,9 +131,9 @@ header {
 
 // Search Styling
 .search-container {
-  position: relative; // For absolute positioning of results
+  position: relative;
   width: 100%;
-  max-width: 500px; // Limit search bar width
+  max-width: 500px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -131,38 +141,41 @@ header {
   input#search-input {
     padding: 0.75em;
     width: 100%;
-    border: 1px solid $border-color;
+    border: 1px solid $border-color; // Updated color
     border-radius: 5px;
     font-size: 1em;
+    font-family: $font-family-sans-serif; // Ensure consistent font
+    color: $text-color;
+    background-color: $card-background;
     &:focus {
       outline: none;
-      border-color: $primary-color;
-      box-shadow: 0 0 0 0.2rem rgba($primary-color, 0.25);
+      border-color: $secondary-color; // Use secondary for focus
+      box-shadow: 0 0 0 0.2rem rgba($secondary-color, 0.25);
     }
   }
 
   ul#search-results {
     list-style-type: none;
-    background: $card-background;
-    border: 1px solid $border-color;
-    border-top: none; // Avoid double border with input
+    background: $card-background; // Updated color
+    border: 1px solid $border-color; // Updated color
+    border-top: none;
     border-radius: 0 0 5px 5px;
     max-height: 400px;
     overflow-y: auto;
     position: absolute;
-    top: 100%; // Position below the input field
+    top: 100%;
     left: 0;
     right: 0;
-    z-index: 1000; // Ensure it's above other content
+    z-index: 1000;
     padding: 0;
-    margin:0; // Reset margin
+    margin:0;
     box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    display: none; // Hidden by default, shown by JS
+    display: none;
 
     li {
       padding: 0.75em 1em;
-      border-bottom: 1px solid $border-color;
-      margin-bottom: 0; // Reset li margin
+      border-bottom: 1px solid $border-color; // Updated color
+      margin-bottom: 0;
 
       &:last-child {
         border-bottom: none;
@@ -170,15 +183,15 @@ header {
 
       a {
         text-decoration: none;
-        color: $link-color;
-        font-weight: bold;
-        display: block; // Make entire area clickable
+        color: $link-color; // Updated color
+        font-weight: bold; // Keep bold for titles
+        display: block;
         &:hover {
-          color: $link-hover-color;
+          color: $link-hover-color; // Updated color
         }
       }
       small {
-        color: lighten($text-color, 20%);
+        color: lighten($text-color, 25%); // Lighter text for excerpts
         display: block;
         font-size: 0.85em;
         margin-top: 0.25em;
@@ -190,100 +203,121 @@ header {
 // Recipe Index Page
 .recipe-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); // Responsive grid
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: 25px;
 }
 
 .recipe-card {
-  background: $card-background;
-  border: 1px solid $border-color;
+  background: $card-background; // Updated color
+  border: 1px solid $border-color; // Updated color
   border-radius: 8px;
   padding: 20px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.05);
-  transition: box-shadow 0.3s ease-in-out;
+  box-shadow: 0 4px 8px rgba(82, 63, 51, 0.08); // Softer shadow with a hint of text color
+  transition: box-shadow 0.3s ease-in-out, transform 0.2s ease-in-out;
 
   &:hover {
-    box-shadow: 0 6px 12px rgba(0,0,0,0.1);
+    box-shadow: 0 6px 12px rgba(82, 63, 51, 0.12);
+    transform: translateY(-3px);
   }
 
-  h2 {
-    font-size: 1.4em;
-    margin-top: 0; // Remove top margin if h2 is first child
+  h2 { // Card Title
+    font-size: 1.6em; // Adjusted size
+    margin-top: 0;
     margin-bottom: 0.5em;
+    color: $primary-color; // Ensure it uses primary color
     a {
-      color: $primary-color; // Use variable
+      color: inherit; // Inherit color from h2
       text-decoration: none;
     }
   }
-  img, .recipe-card-image-placeholder { // Style for actual image and placeholder div
-    width: 100%; // Ensure image takes full width of card
-    height: 180px; // Fixed height for consistency
-    object-fit: cover; // Crop images nicely
+  img, .recipe-card-image-placeholder {
+    width: 100%;
+    height: 180px;
+    object-fit: cover;
     border-radius: 5px;
     margin-bottom: 15px;
-    background-color: #eee; // Placeholder bg
+    background-color: darken($background-color, 5%); // Darker placeholder bg
   }
   p { // Excerpt
     font-size: 0.9em;
-    color: lighten($text-color, 10%);
+    color: lighten($text-color, 15%); // Updated color
     margin-bottom: 1em;
   }
   a:last-of-type { // "Read more" link
     display: inline-block;
     font-weight: bold;
+    color: $secondary-color; // Use secondary for accent
+    &:hover {
+      color: darken($secondary-color, 10%);
+    }
   }
 }
 
 // Recipe Detail Page
 .recipe {
-  background: $card-background;
-  padding: 25px;
-  border: 1px solid $border-color;
+  background: $card-background; // Updated color
+  padding: 30px; // More padding for detail page
+  border: 1px solid $border-color; // Updated color
   border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.05);
+  box-shadow: 0 4px 8px rgba(82, 63, 51, 0.08);
+
+  h1 { // Main Recipe Title on Detail Page
+    font-size: 2.8em; // Larger for main title
+    color: $primary-color;
+    margin-bottom: 0.5em;
+    text-align: center; // Center the main title
+  }
 
   .recipe-image {
     width: 100%;
-    max-height: 400px; // Limit height of main recipe image
+    max-height: 450px; // Slightly more height for main recipe image
     object-fit: cover;
-    border-radius: 5px;
+    border-radius: 8px; // More rounded corners
     margin-bottom: 1.5em;
+    border: 3px solid $border-color; // Optional border around image
   }
 
   .recipe-meta {
     margin-bottom: 1.5em;
-    padding-bottom: 1em;
-    border-bottom: 1px solid $border-color;
+    padding: 1em;
+    border-radius: 5px;
+    background-color: darken($background-color, 3%); // Slightly different bg for meta
+    border-bottom: 1px solid $border-color; // Updated color
     p {
       margin-bottom: 0.5em;
       font-size: 0.95em;
+      color: $text-color; // Updated color
       strong {
-        color: darken($text-color, 15%);
+        color: $primary-color; // Use primary color for emphasis
       }
     }
   }
 
   .ingredients, .instructions {
     margin-bottom: 1.5em;
-    h2 {
-      border-bottom: 2px solid $primary-color;
+    h2 { // Section Headings like "Ingredients", "Instructions"
+      font-size: 1.8em; // Adjusted size
+      color: $primary-color; // Use primary color
+      border-bottom: 2px solid $secondary-color; // Use secondary for underline
       padding-bottom: 0.3em;
       margin-bottom: 0.75em;
-      font-size: 1.5em;
     }
   }
 
   .ingredients ul {
-    list-style-type: none; // Remove default bullets
+    list-style-type: none;
     padding-left: 0;
     li {
-      padding: 0.5em 0;
-      border-bottom: 1px dotted lighten($border-color, 2%);
+      padding: 0.6em 0; // Slightly more padding
+      border-bottom: 1px dashed $border-color; // Dashed border, updated color
+      font-size: 1em;
+      color: $text-color; // Updated color
       &:before {
-        content: "› "; // Custom bullet
-        color: $primary-color;
-        font-weight: bold;
-        margin-right: 8px;
+        content: "🌿"; // Changed custom bullet to a leaf
+        color: $secondary-color; // Use secondary for bullet
+        font-weight: normal; // Keep it light
+        margin-right: 10px;
+        font-size: 1.1em;
       }
       &:last-child {
         border-bottom: none;
@@ -291,24 +325,39 @@ header {
     }
   }
 
+  // Styling for headings within the main recipe content ({{ content }})
   .instructions {
-    h1,h2,h3,h4,h5,h6 { // Reset heading styles if they come from markdown content
-        font-family: $font-family-sans-serif;
-        color: $text-color;
+    h1,h2,h3,h4,h5,h6 {
+        font-family: $font-family-serif; // Consistent with other headings
+        color: $primary-color; // Use primary color
         border-bottom: none;
         padding-bottom: 0;
+        margin-top: 1.5em; // Add space above content headings
+        margin-bottom: 0.5em;
     }
-     h1 { font-size: 1.8em; }
-     h2 { font-size: 1.5em; }
-     h3 { font-size: 1.2em; }
+    // Make content headings subordinate to the main page title (which is H1)
+    // and section titles (Ingredients/Instructions, which are H2)
+     h1 { font-size: 1.6em; } // An H1 in content becomes like a strong H3
+     h2 { font-size: 1.4em; } // An H2 in content becomes like an H4
+     h3 { font-size: 1.2em; } // An H3 in content becomes like an H5
+     h4, h5, h6 { font-size: 1em; }
 
-    // Ensure good readability for instructions
+
     p, li {
       line-height: 1.7;
+      color: $text-color; // Updated color
+      font-size: 1em; // Ensure body text size
     }
     strong, b {
-        font-weight: bold;
-        color: darken($text-color, 10%);
+        font-weight: bold; // Default bold is usually 700, Open Sans 600 is semi-bold
+        color: darken($text-color, 10%); // Updated color
+    }
+    ul, ol {
+      margin-bottom: 1em;
+      li {
+        margin-bottom: 0.5em;
+        // Could add custom bullets for lists within instructions too if desired
+      }
     }
   }
 }
@@ -318,43 +367,44 @@ footer {
   text-align: center;
   padding: 2em 0;
   margin-top: 2em;
-  background-color: darken($background-color, 5%);
-  border-top: 1px solid $border-color;
+  background-color: darken($background-color, 5%); // Updated color
+  border-top: 1px solid $border-color; // Updated color
   p {
     margin: 0;
     font-size: 0.9em;
-    color: lighten($text-color, 20%);
+    color: lighten($text-color, 20%); // Updated color
   }
 }
 
-// Responsive Design
-@media (max-width: 992px) { // Larger tablets
+// Responsive Design (mostly adjustments to new sizes, existing structure is fine)
+@media (max-width: 992px) {
   .container {
     width: 95%;
   }
+  .recipe h1 { font-size: 2.4em; } // Adjust main recipe title
 }
 
-@media (max-width: 768px) { // Tablets
-  body {
-    // padding: 10px; // Removed body padding, use container padding
-  }
+@media (max-width: 768px) {
   header h1 a {
-    font-size: 1.3em;
+    font-size: 1.7em; // Adjust header site title
   }
   .search-container input#search-input {
-    font-size: 0.9em; // Slightly smaller search input on mobile
+    font-size: 0.9em;
   }
   .recipe-list {
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); // Adjust card min size
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   }
   .recipe-card, .recipe {
     padding: 15px;
   }
-  h1 { font-size: 2em; }
-  h2 { font-size: 1.5em; }
+  h1 { font-size: 2.2em; } // Global H1
+  h2 { font-size: 1.8em; } // Global H2
+  .recipe h1 { font-size: 2em; } // Main recipe title on detail
+  .recipe .instructions h1 { font-size: 1.5em; } // H1 within content
+  .recipe .instructions h2 { font-size: 1.3em; } // H2 within content
 }
 
-@media (max-width: 576px) { // Mobile phones
+@media (max-width: 576px) {
   .container {
     padding-left: 10px;
     padding-right: 10px;
@@ -364,24 +414,27 @@ footer {
     margin-bottom: 1.5em;
   }
   header h1 a {
-    font-size: 1.2em;
+    font-size: 1.5em;
   }
 
   .recipe-list {
-    grid-template-columns: 1fr; // Stack cards fully
+    grid-template-columns: 1fr;
     gap: 15px;
   }
 
   .recipe-card img, .recipe-card-image-placeholder {
-    height: 160px; // Adjust image height for smaller cards
+    height: 160px;
   }
-
   .recipe .recipe-image {
     max-height: 300px;
   }
+  .recipe h1 { font-size: 1.8em; } // Main recipe title on detail (mobile)
+  .recipe .instructions h1 { font-size: 1.4em; } // H1 within content (mobile)
+  .recipe .instructions h2 { font-size: 1.2em; } // H2 within content (mobile)
 
   footer {
     padding: 1.5em 0;
     margin-top: 1.5em;
   }
 }
+```

--- a/index.html
+++ b/index.html
@@ -12,10 +12,8 @@ title: Our Recipes
         {% if recipe.image and recipe.image != "" %}
           <a href="{{ recipe.url | relative_url }}">
             <img src="{{ recipe.image | relative_url }}" alt="{{ recipe.title | escape }}" style="max-width: 200px; height: auto;">
-          </a>
-        {% else %}
-          <a href="{{ recipe.url | relative_url }}">
-            <img src="https://source.unsplash.com/400x200/?{{ recipe.title | url_encode }},food,recipe" alt="Placeholder image for {{ recipe.title | escape }}" style="max-width: 200px; height: auto;">
+            {# The style attribute here might be better handled by a class in SCSS for consistency #}
+            {# For now, SCSS rules for .recipe-card img should mostly override this if specific enough #}
           </a>
         {% endif %}
         <p>{{ recipe.excerpt | strip_html | truncatewords: 20 }}</p>

--- a/rezepte/test-image-recipe.md
+++ b/rezepte/test-image-recipe.md
@@ -1,0 +1,26 @@
+---
+layout: something_else
+title: "Original Title from FM"
+image: "/rezepte/images/test-image.jpg"
+prep_time: "10 Min from FM"
+cook_time: "20 Min from FM"
+portions: "2 from FM"
+ingredients:
+  - "1 cup FM ingredient"
+  - "2 tbsp FM other stuff"
+---
+# Actual Recipe Title in Content
+
+This is some intro text.
+
+Vorbereitungszeit: 15 Minuten (from content)
+
+## Zutaten
+
+- 1 kg Content Ingredient
+- 2 tbsp Content Spice
+
+## Zubereitung
+
+1.  Do this.
+2.  Then that.


### PR DESCRIPTION
… theme

This commit implements several user-requested updates:

1.  **Use Local Recipe Images:**
    -   The website now uses images specified in the 'image' front matter field of each recipe, sourced from the 'rezepte/images/' directory.
    -   The Unsplash placeholder image functionality has been removed, prioritizing your provided images.
    -   The Python processing script (`_tools/process_recipes.py`) was updated to ensure it correctly preserves these image paths from the original Markdown files.

2.  **Display Full Markdown Content:**
    -   Recipe pages now render the entire original Markdown content, including all headings, paragraphs, lists, and inline images present in the source files.
    -   The Python script was modified to pass the full content to Jekyll.
    -   CSS was adjusted to ensure headings within the recipe content are styled appropriately and subordinate to main page titles.

3.  **New "Cooking" Theme:**
    -   The website's visual style has been updated to a "cooking" theme.
    -   A new, warmer color palette has been introduced (Terracotta, Muted Gold, Dark Brown, Light Cream).
    -   Typography has been updated using Google Fonts: 'Domine' for headings and 'Open Sans' for body text, enhancing readability and thematic feel.
    -   Styling for various elements (cards, lists, header, footer, etc.) has been refreshed to align with the new theme.

These changes significantly improve the content presentation and visual appeal of the recipe website.